### PR TITLE
Add newlines to Prolog description

### DIFF
--- a/_informatica/prolog.md
+++ b/_informatica/prolog.md
@@ -12,22 +12,29 @@ programmeerparadigma’s. Je denkt dan ongetwijfeld aan objectgeoriënteerd of
 misschien zelfs functioneel programmeren. Maar er zijn er nog veel meer. Eén
 ervan is het paradigma van logisch programmeren. Je werkt dan niet meer met
 statements, klassen of functies, maar met feiten, regels en bewijzen. Sudoku’s
-en andere logische puzzels oplossen is in dit paradigma kinderspel! Bij zulke
-woorden en mooie beloftes denk je misschien dat logisch programmeren een
-nieuwe technologie is. Niets is minder waar: de wiskundedomeinen waar het zijn
-werking aan dankt, lambda calculus en formele logica, zijn nog veel ouder dan
-de moderne informatica. En Prolog, de programmeertaal waar we mee aan de slag
-gaan, viert dit jaar haar vijftigste verjaardag. In deze workshop vertelt
-Wouter je over de verschillende programmeerparadigma’s en gaan we samen aan de
-slag door te puzzelen met Prolog. Met een online editor kun je snel zelf aan
-de slag om je eerste regels in deze ‘nieuwe’ taal te schrijven. Veel docenten
-denken dat logisch programmeren te moeilijk of niet interessant genoeg is om
-in te zetten in de les. In het najaar van 2021 is het keuzethema uitgebreid
-getest op een middelbare school. We vertellen over de ervaringen en gaan graag
-het gesprek aan, want onze ervaring is precies het tegenovergestelde!
+en andere logische puzzels oplossen is in dit paradigma kinderspel!
 
-Wouter van den Brink is, na het afronden van zijn bachelor Technical Computer
+Bij zulke woorden en mooie beloftes denk je misschien dat logisch programmeren
+een nieuwe technologie is. Niets is minder waar: de wiskundedomeinen waar het
+zijn werking aan dankt, lambda calculus en formele logica, zijn nog veel ouder
+dan de moderne informatica. En Prolog, de programmeertaal waar we mee aan de
+slag gaan, viert dit jaar haar vijftigste verjaardag.
+
+In deze workshop vertelt Wouter je over de verschillende
+programmeerparadigma’s en gaan we samen aan de slag door te puzzelen met
+Prolog. Met een online editor kun je snel zelf aan de slag om je eerste regels
+in deze ‘nieuwe’ taal te schrijven.
+
+Veel docenten denken dat logisch programmeren te moeilijk of niet interessant
+genoeg is om in te zetten in de les. In het najaar van 2021 is het keuzethema
+uitgebreid getest op een middelbare school. We vertellen over de ervaringen en
+gaan graag het gesprek aan, want onze ervaring is precies het
+tegenovergestelde!
+
+
+
+*Wouter van den Brink is, na het afronden van zijn bachelor Technical Computer
 Science, verder gegaan voor de eerstegraads lesbevoegdheid aan de Universiteit
-Twente. Hiernaast is hij, samen met Adriaan Gijssen, werkzaam bij Instruct.
-Daar heeft hij onder andere het keuzethema “Logisch Programmeren met Prolog”
-voor domein J geschreven.
+Twente. Hiernaast is hij, samen met Adriaan Gijssen, werkzaam bij Instruct. Daar
+heeft hij onder andere het keuzethema “Logisch Programmeren met Prolog” voor
+domein J geschreven.*


### PR DESCRIPTION
The description for the Prolog workshop was missing some newlines present in the submitted document. This made the description a daunting wall of text. This commit adds the newlines and formats the authors' bio.

Tested on my fork -- feel free to [view the new version](https://woutervdbrink.github.io/ieni2022/informatica/prolog.html).